### PR TITLE
Possible fix for conflicting scoreboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 output/
 target/
 ScoreboardLib.iml
+scoreboard.iml

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
             <version>4.0.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/me/tigerhix/lib/scoreboard/ScoreboardLib.java
+++ b/src/main/java/me/tigerhix/lib/scoreboard/ScoreboardLib.java
@@ -24,9 +24,9 @@ public final class ScoreboardLib extends JavaPlugin {
     ScoreboardLib.instance = instance;
   }
 
-  public static Scoreboard createScoreboard(Player holder) {
+  public static Scoreboard createScoreboard(Player holder, String board_name) {
     if(Bukkit.getPluginManager().isPluginEnabled("ProtocolSupport")) {
-      return new LegacySimpleScoreboard(holder);
+      return new LegacySimpleScoreboard(holder,board_name);
     }
     if(Bukkit.getPluginManager().isPluginEnabled("ViaVersion")) {
       try {
@@ -34,15 +34,15 @@ public final class ScoreboardLib extends JavaPlugin {
         int version = api.getPlayerVersion(holder); // Get the protocol version
         if(version > 404 && ServerVersion.Version.isCurrentEqualOrHigher(ServerVersion.Version.v1_14_R1)) {
           //only give player & server higher 1.13 the better scoreboard
-          return new SimpleScoreboard(holder);
+          return new SimpleScoreboard(holder,board_name);
         }
       } catch(Exception ignored) {
         //Not using ViaVersion 4 or unable to get ViaVersion return LegacyBoard!
       }
     } else if(ServerVersion.Version.isCurrentEqualOrHigher(ServerVersion.Version.v1_14_R1)) {
-      return new SimpleScoreboard(holder);
+      return new SimpleScoreboard(holder,board_name);
     }
-    return new LegacySimpleScoreboard(holder);
+    return new LegacySimpleScoreboard(holder,board_name);
   }
 
   @Override

--- a/src/main/java/me/tigerhix/lib/scoreboard/ScoreboardLib.java
+++ b/src/main/java/me/tigerhix/lib/scoreboard/ScoreboardLib.java
@@ -10,6 +10,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Random;
 
 public final class ScoreboardLib extends JavaPlugin {
 
@@ -24,7 +27,25 @@ public final class ScoreboardLib extends JavaPlugin {
     ScoreboardLib.instance = instance;
   }
 
-  public static Scoreboard createScoreboard(Player holder, String board_name) {
+  public static Scoreboard createScoreboard(Player holder, @Nullable String new_board_name) {
+    String board_name;
+    if (new_board_name!=null && new_board_name.length()>0) {
+      board_name=new_board_name;
+    } else {
+      int leftLimit = 48; // numeral '0'
+      int rightLimit = 122; // letter 'z'
+      int targetStringLength = 6;
+      Random random = new Random();
+
+      //Unique String Generator
+      String generatedString = random.ints(leftLimit, rightLimit + 1)
+              .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+              .limit(targetStringLength)
+              .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+              .toString();
+
+      board_name=generatedString;
+    }
     if(Bukkit.getPluginManager().isPluginEnabled("ProtocolSupport")) {
       return new LegacySimpleScoreboard(holder,board_name);
     }

--- a/src/main/java/me/tigerhix/lib/scoreboard/type/LegacySimpleScoreboard.java
+++ b/src/main/java/me/tigerhix/lib/scoreboard/type/LegacySimpleScoreboard.java
@@ -38,11 +38,11 @@ public class LegacySimpleScoreboard implements Scoreboard {
     private Table<Team, String, String> teamCache = HashBasedTable.create();
     private BukkitRunnable updateTask;
 
-    public LegacySimpleScoreboard(Player holder) {
+    public LegacySimpleScoreboard(Player holder,String board_name) {
         this.holder = holder;
         // Initiate the Bukkit scoreboard
         scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
-        scoreboard.registerNewObjective("board", "dummy").setDisplaySlot(DisplaySlot.SIDEBAR);
+        scoreboard.registerNewObjective("board_"+board_name, "dummy").setDisplaySlot(DisplaySlot.SIDEBAR);
         objective = scoreboard.getObjective(DisplaySlot.SIDEBAR);
     }
 

--- a/src/main/java/me/tigerhix/lib/scoreboard/type/SimpleScoreboard.java
+++ b/src/main/java/me/tigerhix/lib/scoreboard/type/SimpleScoreboard.java
@@ -29,11 +29,11 @@ public class SimpleScoreboard implements Scoreboard {
     private ScoreboardHandler handler;
     private BukkitTask updateTask;
 
-    public SimpleScoreboard(Player holder) {
+    public SimpleScoreboard(Player holder,String board_name) {
         this.holder = holder;
         // Initiate the Bukkit scoreboard
         scoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
-        scoreboard.registerNewObjective("board", "dummy").setDisplaySlot(DisplaySlot.SIDEBAR);
+        scoreboard.registerNewObjective("board_"+board_name, "dummy").setDisplaySlot(DisplaySlot.SIDEBAR);
         objective = scoreboard.getObjective(DisplaySlot.SIDEBAR);
         for (int i = 1; i <= 15; i++) {
             Team team = scoreboard.registerNewTeam(TEAM_PREFIX + i);


### PR DESCRIPTION
I think that if multiple projects will use the same scoreboard name it may create conflicts so it would be best to add a board name value so each plugin could have own unique scoreboard.